### PR TITLE
Fix tracked-link ig query attribution

### DIFF
--- a/apps/worker/src/routes/tracked-links.test.ts
+++ b/apps/worker/src/routes/tracked-links.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { trackedLinks } from './tracked-links.js';
+
+const dbMocks = vi.hoisted(() => ({
+  addTagToFriend: vi.fn(),
+  createTrackedLink: vi.fn(),
+  deleteTrackedLink: vi.fn(),
+  enrollFriendInScenario: vi.fn(),
+  getFriendByIgsid: vi.fn(),
+  getLinkClicks: vi.fn(),
+  getTrackedLinkById: vi.fn(),
+  getTrackedLinks: vi.fn(),
+  recordLinkClick: vi.fn(),
+}));
+
+vi.mock('@ig-harness/db', () => dbMocks);
+
+function makeExecutionCtx() {
+  const pending: Promise<unknown>[] = [];
+  return {
+    pending,
+    ctx: {
+      waitUntil(promise: Promise<unknown>) {
+        pending.push(promise);
+      },
+    } as ExecutionContext,
+  };
+}
+
+describe('tracked links route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves friend attribution from the ig query parameter before recording the click', async () => {
+    dbMocks.getTrackedLinkById.mockResolvedValue({
+      id: 'link-1',
+      name: 'Reward',
+      original_url: 'https://example.com/reward',
+      tag_id: 'tag-1',
+      scenario_id: 'scenario-1',
+      is_active: 1,
+      click_count: 0,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+    dbMocks.getFriendByIgsid.mockResolvedValue({ id: 'friend-1' });
+    dbMocks.recordLinkClick.mockResolvedValue({ id: 'click-1' });
+    dbMocks.addTagToFriend.mockResolvedValue(undefined);
+    dbMocks.enrollFriendInScenario.mockResolvedValue(undefined);
+
+    const env = { DB: {} as D1Database };
+    const { ctx, pending } = makeExecutionCtx();
+    const response = await trackedLinks.fetch(
+      new Request('https://worker.example.com/t/link-1?ig=IGSID42'),
+      env,
+      ctx,
+    );
+    await Promise.all(pending);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('https://example.com/reward');
+    expect(dbMocks.getFriendByIgsid).toHaveBeenCalledWith(env.DB, 'IGSID42');
+    expect(dbMocks.recordLinkClick).toHaveBeenCalledWith(env.DB, 'link-1', 'friend-1');
+    expect(dbMocks.addTagToFriend).toHaveBeenCalledWith(env.DB, 'friend-1', 'tag-1');
+    expect(dbMocks.enrollFriendInScenario).toHaveBeenCalledWith(env.DB, 'friend-1', 'scenario-1');
+  });
+});

--- a/apps/worker/src/routes/tracked-links.ts
+++ b/apps/worker/src/routes/tracked-links.ts
@@ -6,7 +6,6 @@ import {
   deleteTrackedLink,
   recordLinkClick,
   getLinkClicks,
-  getFriendByLineUserId,
 } from '@ig-harness/db';
 import { addTagToFriend, enrollFriendInScenario } from '@ig-harness/db';
 import type { TrackedLink } from '@ig-harness/db';
@@ -196,7 +195,7 @@ function buildAppRedirectHtml(destinationUrl: string): string {
 // GET /t/:linkId — click tracking redirect (no auth, fast redirect)
 trackedLinks.get('/t/:linkId', async (c) => {
   const linkId = c.req.param('linkId');
-  const lineUserId = c.req.query('lu') ?? null;
+  const igsid = c.req.query('ig') ?? c.req.query('lu') ?? null;
   let friendId = c.req.query('f') ?? null;
 
   // Look up the link first
@@ -209,11 +208,11 @@ trackedLinks.get('/t/:linkId', async (c) => {
   const useAppRedirect = isAppLinkDomain(link.original_url);
 
   // Resolve friendId from IGSID if provided
-  if (!friendId && lineUserId) {
+  if (!friendId && igsid) {
     const { getFriendByIgsid } = await import('@ig-harness/db');
-    const friend = await getFriendByIgsid(c.env.DB, lineUserId);
+    const friend = await getFriendByIgsid(c.env.DB, igsid);
     if (friend) {
-      friendId = friend.id;
+      friendId = String(friend.id);
     }
   }
 


### PR DESCRIPTION
## Summary
- accept tracked-link click attribution from the ig query parameter emitted by the cross-link flow
- keep lu as a fallback and normalize resolved friend IDs before recording clicks
- add focused tracked-links route coverage for click attribution side effects

## Verification
- pnpm --filter worker exec vitest run src/routes/tracked-links.test.ts
- pnpm --filter @ig-harness/ig-sdk build
- pnpm --filter worker build
- pnpm --filter worker test (still fails in src/services/__tests__/engagement-gate.test.ts: creates a delivery and sends CTA DM when gate matches)
- pnpm --filter worker typecheck (still fails on pre-existing worker type mismatches outside tracked-links)