### PR TITLE
fix(mcp): restore direct typecheck baseline

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,7 +8,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ig-harness/sdk": "workspace:*",
@@ -16,6 +17,7 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
+    "@types/node": "^22.19.15",
     "tsup": "^8.4.0",
     "typescript": "^5.9.3"
   }

--- a/packages/mcp-server/src/tools/manage-ad-platforms.ts
+++ b/packages/mcp-server/src/tools/manage-ad-platforms.ts
@@ -136,12 +136,13 @@ export function registerManageAdPlatforms(server: McpServer): void {
               eventName,
               friendId,
             );
+            const { success: _ignored, ...details } = result;
 
             return {
               content: [
                 {
                   type: "text" as const,
-                  text: JSON.stringify({ success: true, ...result }, null, 2),
+                  text: JSON.stringify({ success: true, ...details }, null, 2),
                 },
               ],
             };

--- a/packages/mcp-server/src/tools/manage-broadcasts.ts
+++ b/packages/mcp-server/src/tools/manage-broadcasts.ts
@@ -26,7 +26,7 @@ export function registerManageBroadcasts(server: McpServer): void {
 
         if (action === "list") {
           const broadcasts = await client.broadcasts.list();
-          const enriched = (broadcasts as Array<Record<string, unknown>>).map((b) => ({
+          const enriched = (broadcasts as unknown as Array<Record<string, unknown>>).map((b) => ({
             ...b,
             insightStatus: b.insight_status || null,
             openRate: b.open_rate != null
@@ -55,7 +55,7 @@ export function registerManageBroadcasts(server: McpServer): void {
 
         if (action === "get") {
           const broadcast = await client.broadcasts.get(broadcastId);
-          const row = broadcast as Record<string, unknown>;
+          const row = broadcast as unknown as Record<string, unknown>;
           const insight = row.insight_status
             ? {
                 status: row.insight_status,

--- a/packages/mcp-server/src/tools/manage-staff.ts
+++ b/packages/mcp-server/src/tools/manage-staff.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getClient } from "../client.js";
+import type { CreateStaffInput, UpdateStaffInput } from "@ig-harness/sdk";
 
 export function registerManageStaff(server: McpServer): void {
   server.tool(
@@ -37,7 +38,9 @@ export function registerManageStaff(server: McpServer): void {
         if (action === "create") {
           if (!name) throw new Error("name is required for create action");
           if (!role) throw new Error("role is required for create action");
-          const member = await client.staff.create({ name, email, role });
+          const input: CreateStaffInput = { name, role };
+          if (email !== undefined && email !== null) input.email = email;
+          const member = await client.staff.create(input);
           return {
             content: [{
               type: "text" as const,
@@ -59,7 +62,7 @@ export function registerManageStaff(server: McpServer): void {
 
         if (action === "update") {
           if (!staffId) throw new Error("staffId is required for update action");
-          const updates: Record<string, unknown> = {};
+          const updates: UpdateStaffInput = {};
           if (name !== undefined) updates.name = name;
           if (email !== undefined) updates.email = email;
           if (role !== undefined) updates.role = role;

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,8 +1,10 @@
 import { HttpClient } from './http.js'
+import { FriendsResource } from './resources/friends.js'
 import { FollowersResource } from './resources/followers.js'
 import { TagsResource } from './resources/tags.js'
 import { ScenariosResource } from './resources/scenarios.js'
 import { BroadcastsResource } from './resources/broadcasts.js'
+import { RichMenusResource } from './resources/rich-menus.js'
 import { CommentRulesResource } from './resources/comment-rules.js'
 import { TrackedLinksResource } from './resources/tracked-links.js'
 import { FormsResource } from './resources/forms.js'
@@ -12,13 +14,16 @@ import { EngagementGatesResource } from './resources/engagement-gates.js'
 import { LineConnectionsResource } from './resources/line-connections.js'
 import { RichMessagesResource } from './resources/rich-messages.js'
 import { PostsResource } from './resources/posts.js'
+import { AdPlatformsResource } from './resources/ad-platforms.js'
 import type { InstagramHarnessConfig } from './types.js'
 
 export class InstagramHarness {
+  readonly friends: FriendsResource
   readonly followers: FollowersResource
   readonly tags: TagsResource
   readonly scenarios: ScenariosResource
   readonly broadcasts: BroadcastsResource
+  readonly richMenus: RichMenusResource
   readonly commentRules: CommentRulesResource
   readonly trackedLinks: TrackedLinksResource
   readonly forms: FormsResource
@@ -28,6 +33,7 @@ export class InstagramHarness {
   readonly lineConnections: LineConnectionsResource
   readonly richMessages: RichMessagesResource
   readonly posts: PostsResource
+  readonly adPlatforms: AdPlatformsResource
 
   constructor(config: InstagramHarnessConfig) {
     const apiUrl = config.apiUrl.replace(/\/$/, '')
@@ -38,10 +44,12 @@ export class InstagramHarness {
       timeout: config.timeout ?? 30_000,
     })
 
+    this.friends = new FriendsResource(http)
     this.followers = new FollowersResource(http)
     this.tags = new TagsResource(http)
     this.scenarios = new ScenariosResource(http)
     this.broadcasts = new BroadcastsResource(http)
+    this.richMenus = new RichMenusResource(http)
     this.commentRules = new CommentRulesResource(http)
     this.trackedLinks = new TrackedLinksResource(http)
     this.forms = new FormsResource(http)
@@ -51,5 +59,6 @@ export class InstagramHarness {
     this.lineConnections = new LineConnectionsResource(http)
     this.richMessages = new RichMessagesResource(http)
     this.posts = new PostsResource(http)
+    this.adPlatforms = new AdPlatformsResource(http)
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,10 +3,12 @@ export { InstagramHarnessError } from './errors.js'
 export { parseDelay } from './delay.js'
 
 // Resource classes (for advanced usage / type narrowing)
+export { FriendsResource } from './resources/friends.js'
 export { FollowersResource } from './resources/followers.js'
 export { TagsResource } from './resources/tags.js'
 export { ScenariosResource } from './resources/scenarios.js'
 export { BroadcastsResource } from './resources/broadcasts.js'
+export { RichMenusResource } from './resources/rich-menus.js'
 export { CommentRulesResource } from './resources/comment-rules.js'
 export { TrackedLinksResource } from './resources/tracked-links.js'
 export { FormsResource } from './resources/forms.js'
@@ -14,6 +16,7 @@ export { StaffResource } from './resources/staff.js'
 export { ImagesResource } from './resources/images.js'
 export { EngagementGatesResource } from './resources/engagement-gates.js'
 export { LineConnectionsResource } from './resources/line-connections.js'
+export { AdPlatformsResource } from './resources/ad-platforms.js'
 
 // All types
 export type {
@@ -23,6 +26,8 @@ export type {
   ScenarioTriggerType,
   MessageType,
   BroadcastStatus,
+  Friend,
+  FriendListParams,
   Follower,
   FollowerListParams,
   Tag,
@@ -39,6 +44,17 @@ export type {
   Broadcast,
   CreateBroadcastInput,
   UpdateBroadcastInput,
+  RichMenu,
+  CreateRichMenuInput,
+  RichMenuAction,
+  RichMenuArea,
+  RichMenuBounds,
+  AdPlatform,
+  AdPlatformName,
+  ConversionLog,
+  ConversionLogStatus,
+  CreateAdPlatformInput,
+  UpdateAdPlatformInput,
   SegmentRule,
   SegmentCondition,
   StepDefinition,

--- a/packages/sdk/src/resources/ad-platforms.ts
+++ b/packages/sdk/src/resources/ad-platforms.ts
@@ -1,0 +1,51 @@
+import type { HttpClient } from '../http.js'
+import type {
+  AdPlatform,
+  AdPlatformName,
+  ApiResponse,
+  ConversionLog,
+  CreateAdPlatformInput,
+  UpdateAdPlatformInput,
+} from '../types.js'
+
+export class AdPlatformsResource {
+  constructor(private readonly http: HttpClient) {}
+
+  async list(): Promise<AdPlatform[]> {
+    const res = await this.http.get<ApiResponse<AdPlatform[]>>('/api/ad-platforms')
+    return res.data
+  }
+
+  async create(input: CreateAdPlatformInput): Promise<AdPlatform> {
+    const res = await this.http.post<ApiResponse<AdPlatform>>('/api/ad-platforms', input)
+    return res.data
+  }
+
+  async update(id: string, input: UpdateAdPlatformInput): Promise<AdPlatform> {
+    const res = await this.http.patch<ApiResponse<AdPlatform>>(`/api/ad-platforms/${id}`, input)
+    return res.data
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.http.delete(`/api/ad-platforms/${id}`)
+  }
+
+  async test(
+    name: AdPlatformName,
+    eventName: string,
+    friendId?: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const res = await this.http.post<ApiResponse<{ success: boolean; error?: string }>>(
+      '/api/ad-platforms/test',
+      { name, eventName, friendId },
+    )
+    return res.data
+  }
+
+  async getLogs(platformId: string, limit = 50): Promise<ConversionLog[]> {
+    const res = await this.http.get<ApiResponse<ConversionLog[]>>(
+      `/api/ad-platforms/${platformId}/logs?limit=${limit}`,
+    )
+    return res.data
+  }
+}

--- a/packages/sdk/src/resources/friends.ts
+++ b/packages/sdk/src/resources/friends.ts
@@ -1,0 +1,72 @@
+import type { HttpClient } from '../http.js'
+import type { ApiResponse, Friend, FriendListParams, PaginatedData } from '../types.js'
+
+export class FriendsResource {
+  constructor(private readonly http: HttpClient) {}
+
+  async list(params?: FriendListParams): Promise<PaginatedData<Friend>> {
+    const query = new URLSearchParams()
+    if (params?.limit !== undefined) query.set('limit', String(params.limit))
+    if (params?.offset !== undefined) query.set('offset', String(params.offset))
+    if (params?.tagId !== undefined) query.set('tagId', params.tagId)
+    if (params?.search) query.set('search', params.search)
+    if (params?.accountId) query.set('accountId', params.accountId)
+    if (params?.metadata) {
+      for (const [key, value] of Object.entries(params.metadata)) {
+        query.set(`metadata[${key}]`, value)
+      }
+    }
+    const qs = query.toString()
+    const res = await this.http.get<ApiResponse<PaginatedData<Friend>>>(
+      qs ? `/api/friends?${qs}` : '/api/friends',
+    )
+    return res.data
+  }
+
+  async get(id: string): Promise<Friend> {
+    const res = await this.http.get<ApiResponse<Friend>>(`/api/friends/${id}`)
+    return res.data
+  }
+
+  async count(): Promise<number> {
+    const res = await this.http.get<ApiResponse<{ count: number }>>('/api/friends/count')
+    return res.data.count
+  }
+
+  async addTag(friendId: string, tagId: string): Promise<void> {
+    await this.http.post(`/api/friends/${friendId}/tags`, { tagId })
+  }
+
+  async removeTag(friendId: string, tagId: string): Promise<void> {
+    await this.http.delete(`/api/friends/${friendId}/tags/${tagId}`)
+  }
+
+  async sendMessage(
+    friendId: string,
+    content: string,
+    messageType = 'text',
+    altText?: string,
+  ): Promise<{ messageId: string }> {
+    const res = await this.http.post<ApiResponse<{ messageId: string }>>(
+      `/api/friends/${friendId}/messages`,
+      { messageType, content, altText },
+    )
+    return res.data
+  }
+
+  async setMetadata(friendId: string, fields: Record<string, unknown>): Promise<Friend> {
+    const res = await this.http.put<ApiResponse<Friend>>(
+      `/api/friends/${friendId}/metadata`,
+      fields,
+    )
+    return res.data
+  }
+
+  async setRichMenu(friendId: string, richMenuId: string): Promise<void> {
+    await this.http.post(`/api/friends/${friendId}/rich-menu`, { richMenuId })
+  }
+
+  async removeRichMenu(friendId: string): Promise<void> {
+    await this.http.delete(`/api/friends/${friendId}/rich-menu`)
+  }
+}

--- a/packages/sdk/src/resources/rich-menus.ts
+++ b/packages/sdk/src/resources/rich-menus.ts
@@ -1,0 +1,28 @@
+import type { HttpClient } from '../http.js'
+import type { ApiResponse, CreateRichMenuInput, RichMenu } from '../types.js'
+
+export class RichMenusResource {
+  constructor(private readonly http: HttpClient) {}
+
+  async list(): Promise<RichMenu[]> {
+    const res = await this.http.get<ApiResponse<RichMenu[]>>('/api/rich-menus')
+    return res.data
+  }
+
+  async create(input: CreateRichMenuInput): Promise<RichMenu> {
+    const res = await this.http.post<ApiResponse<RichMenu>>('/api/rich-menus', input)
+    return res.data
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.http.delete(`/api/rich-menus/${id}`)
+  }
+
+  async setDefault(id: string): Promise<void> {
+    await this.http.post(`/api/rich-menus/${id}/default`, {})
+  }
+
+  async uploadImage(id: string, imageData: string, contentType: string): Promise<void> {
+    await this.http.post(`/api/rich-menus/${id}/image`, { imageData, contentType })
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -242,6 +242,45 @@ export interface CreateRichMenuInput {
   areas: RichMenuArea[]
 }
 
+// ─── Ad Platforms ──────────────────────────────────────
+export type AdPlatformName = 'meta' | 'x' | 'google' | 'tiktok'
+
+export interface AdPlatform {
+  id: string
+  name: AdPlatformName
+  displayName: string | null
+  config: Record<string, unknown>
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateAdPlatformInput {
+  name: AdPlatformName
+  displayName?: string
+  config: Record<string, unknown>
+}
+
+export interface UpdateAdPlatformInput {
+  name?: AdPlatformName
+  displayName?: string
+  config?: Record<string, unknown>
+  isActive?: boolean
+}
+
+export type ConversionLogStatus = 'sent' | 'failed'
+
+export interface ConversionLog {
+  id: string
+  platformId: string
+  eventName: string
+  friendId: string | null
+  status: ConversionLogStatus
+  error: string | null
+  sentAt: string | null
+  createdAt: string
+}
+
 // ─── Segment ─────────────────────────────────────────────
 export interface SegmentRule {
   type: 'tag_exists' | 'tag_not_exists' | 'metadata_equals' | 'metadata_not_equals' | 'ref_code' | 'is_following'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
         specifier: ^3.24.4
         version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- add SDK compatibility resources for MCP-facing friends, rich menu, and ad platform APIs
- add direct MCP typecheck script and Node typings
- clean up strict MCP tool type errors around ad platform, broadcast, and staff calls

## Verification
- pnpm --filter @ig-harness/sdk typecheck
- pnpm --filter @ig-harness/sdk build
- pnpm --filter @ig-harness/mcp-server typecheck
- pnpm --filter @ig-harness/mcp-server build
- pnpm --filter @ig-harness/sdk test -- resources/friends.test.ts
- git diff --check