### PR TITLE
fix(worker): restore engagement gate test baseline

### DIFF
--- a/apps/worker/src/services/__tests__/engagement-gate.test.ts
+++ b/apps/worker/src/services/__tests__/engagement-gate.test.ts
@@ -14,6 +14,11 @@ function createMockDb() {
         if (sql.includes('FROM engagement_gates') && sql.includes('WHERE id = ?')) {
           return gates.find((g) => g.id === params[0]) ?? null;
         }
+        // packages/db createGateDelivery does INSERT then SELECT-by-id to
+        // return the new row; mock must handle that lookup too.
+        if (sql.includes('FROM gate_deliveries') && sql.includes('WHERE id = ?')) {
+          return deliveries.find((d) => d.id === params[0]) ?? null;
+        }
         if (sql.includes('FROM gate_deliveries') && sql.includes('WHERE gate_id = ? AND follower_id = ?')) {
           return deliveries.find((d) => d.gate_id === params[0] && d.follower_id === params[1]) ?? null;
         }


### PR DESCRIPTION
## Summary
- Fix the worker engagement-gate test mock to support createGateDelivery's insert-then-select-by-id behavior.
- Keep the production implementation unchanged.

## Verification
- pnpm --filter worker exec vitest run src/services/__tests__/engagement-gate.test.ts
- git diff --check

## Notes
- Full worker test still reports the pre-existing webhook-postback module-resolution baseline outside this diff.
- Worker typecheck still has broader pre-existing baseline errors handled separately.