### PR TITLE
fix(worker): restore typecheck baseline

### DIFF
--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -224,7 +224,9 @@ forms.post('/api/forms/:id/submit', async (c) => {
     if (!friendId && body.lineUserId) {
       const friend = await getFriendByLineUserId(c.env.DB, body.lineUserId);
       if (friend) {
-        friendId = friend.id;
+        // followers.id is numeric in SQLite — coerce so downstream string-typed
+        // helpers (createFormSubmission, addTagToFriend, ...) get a consistent shape.
+        friendId = String(friend.id);
       }
     }
 

--- a/apps/worker/src/routes/scenarios.ts
+++ b/apps/worker/src/routes/scenarios.ts
@@ -45,7 +45,7 @@ function serializeStep(row: DbScenarioStep) {
     stepOrder: row.step_order,
     delayMinutes: row.delay_minutes,
     messageType: row.message_type,
-    messageContent: row.message_content,
+    messageContent: row.body,
     conditionType: row.condition_type ?? null,
     conditionValue: row.condition_value ?? null,
     nextStepOnFalse: row.next_step_on_false ?? null,
@@ -57,12 +57,12 @@ function serializeStep(row: DbScenarioStep) {
 function serializeFriendScenario(row: DbFriendScenario) {
   return {
     id: row.id,
-    friendId: row.friend_id,
+    friendId: row.follower_id,
     scenarioId: row.scenario_id,
-    currentStepOrder: row.current_step_order,
+    currentStepOrder: row.current_step,
     status: row.status,
-    startedAt: row.started_at,
-    nextDeliveryAt: row.next_delivery_at,
+    startedAt: row.enrolled_at,
+    nextDeliveryAt: row.next_step_at,
     updatedAt: row.updated_at,
   };
 }
@@ -266,7 +266,7 @@ scenarios.put('/api/scenarios/:id/steps/:stepId', async (c) => {
       step_order: body.stepOrder,
       delay_minutes: body.delayMinutes,
       message_type: body.messageType,
-      message_content: body.messageContent,
+      body: body.messageContent,
       condition_type: body.conditionType,
       condition_value: body.conditionValue,
       next_step_on_false: body.nextStepOnFalse,

--- a/apps/worker/src/routes/tracked-links.ts
+++ b/apps/worker/src/routes/tracked-links.ts
@@ -213,7 +213,8 @@ trackedLinks.get('/t/:linkId', async (c) => {
     const { getFriendByIgsid } = await import('@ig-harness/db');
     const friend = await getFriendByIgsid(c.env.DB, lineUserId);
     if (friend) {
-      friendId = friend.id;
+      // followers.id is numeric — coerce so it matches the string-typed slot.
+      friendId = String(friend.id);
     }
   }
 

--- a/apps/worker/src/services/__tests__/line-cross-link.test.ts
+++ b/apps/worker/src/services/__tests__/line-cross-link.test.ts
@@ -88,6 +88,7 @@ function makeGate(overrides: Partial<EngagementGate> = {}): EngagementGate {
     follow_reminder_dm_rich_message_id: null,
     comment_reply_text: null,
     followup_dm_sequence: null,
+    allow_repeat: 0,
     line_connection_id: null,
     line_pool_slug: null,
     line_tracked_link_short: null,

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -19,12 +19,16 @@ import { jitterDeliveryTime, addJitter, sleep } from './stealth.js';
  */
 export function expandVariables(
   content: string,
-  friend: { id: string; display_name: string | null; username?: string | null },
+  // `Friend.id` from packages/db is `number` (followers.id INTEGER PRIMARY KEY),
+  // but other callers (e.g., enrollment paths from JSON-decoded API bodies)
+  // pass it as a string. Accept either and coerce — `replace()`'s second arg
+  // must be a string.
+  friend: { id: string | number; display_name: string | null; username?: string | null },
 ): string {
   let result = content;
   result = result.replace(/\{\{name\}\}/g, friend.display_name || friend.username || '');
   result = result.replace(/\{\{username\}\}/g, (friend as unknown as Record<string, unknown>).username as string || '');
-  result = result.replace(/\{\{friend_id\}\}/g, friend.id);
+  result = result.replace(/\{\{friend_id\}\}/g, String(friend.id));
   return result;
 }
 

--- a/packages/db/src/scenarios.ts
+++ b/packages/db/src/scenarios.ts
@@ -305,7 +305,10 @@ export async function getScenarioSteps(
 
 export async function enrollFriendInScenario(
   db: D1Database,
-  friendId: string,
+  // followers.id is INTEGER PRIMARY KEY in SQLite, so callers reading rows
+  // directly hand us a number. Other callers (API routes resolving IDs via
+  // route params) pass strings. D1 accepts both via `.bind()`.
+  friendId: string | number,
   scenarioId: string,
 ): Promise<FriendScenario> {
   const id = crypto.randomUUID();

--- a/packages/db/src/tags.ts
+++ b/packages/db/src/tags.ts
@@ -74,7 +74,9 @@ export async function removeTagFromFriend(
 
 export async function getFriendTags(
   db: D1Database,
-  friendId: string,
+  // followers.id is numeric in SQLite; route params arrive as string. Both
+  // bind cleanly through D1.
+  friendId: string | number,
 ): Promise<Tag[]> {
   const result = await db
     .prepare(

--- a/packages/ig-sdk/src/types.ts
+++ b/packages/ig-sdk/src/types.ts
@@ -40,11 +40,10 @@ export interface Postback {
   payload: string;
 }
 
-// ── Change Events (Comments) ──
-export interface ChangeEvent {
-  field: "comments" | "mentions" | "story_insights";
-  value: CommentValue;
-}
+// ── Change Events (Comments / Mentions / Story Insights) ──
+// Discriminated union on `field` so consumers can narrow `value` after
+// checking `field`. Previously `value` was always typed as `CommentValue`,
+// which broke `handleMentionEvent` whose payload shape is different.
 
 export interface CommentValue {
   id: string;
@@ -53,6 +52,21 @@ export interface CommentValue {
   media: { id: string; media_product_type: string };
   created_time: string;
 }
+
+export interface MentionValue {
+  media_id?: string;
+  comment_id?: string;
+  mentioned_user_id?: string;
+}
+
+export interface StoryInsightsValue {
+  [key: string]: unknown;
+}
+
+export type ChangeEvent =
+  | { field: "comments"; value: CommentValue }
+  | { field: "mentions"; value: MentionValue }
+  | { field: "story_insights"; value: StoryInsightsValue };
 
 // ── Send API Types ──
 export interface SendTextPayload {


### PR DESCRIPTION
## Summary
- Restore the worker TypeScript baseline by aligning IG worker route/service types with current DB and SDK shapes.
- Preserve runtime behavior while normalizing string/number IDs and current column names.
- Update the line-cross-link test factory for the current scenario shape.

## Verification
- pnpm --filter worker typecheck
- pnpm --filter @ig-harness/ig-sdk build
- pnpm --filter worker build
- git diff --check

## Notes
- worker build exits 0; Wrangler still logs an EPERM warning while trying to write under ~/.wrangler/logs in the sandbox.
- Full worker tests still include the separate engagement-gate baseline fixed in PR #7.