### PR TITLE
fix(worker): guard missing assets binding

### DIFF
--- a/apps/worker/src/__tests__/not-found.test.ts
+++ b/apps/worker/src/__tests__/not-found.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleNotFound } from '../index.js';
+
+// Regression test for Shudesu/ig-harness-oss issue #3:
+//   "TypeError: Cannot read properties of undefined (reading 'fetch')"
+//
+// create-ig-harness's deploy template omits [assets], so `env.ASSETS` is
+// undefined at runtime. The notFound fallback used to call
+// `env.ASSETS.fetch(...)` unconditionally and throw.
+
+describe('handleNotFound (issue #3 regression)', () => {
+  it('does NOT call fetch on an undefined ASSETS binding for GET /', async () => {
+    const res = await handleNotFound(new Request('https://example.workers.dev/'), undefined);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body).toEqual({ success: false, error: 'Not found' });
+  });
+
+  it('returns JSON 404 for unknown API paths even when ASSETS is undefined', async () => {
+    const res = await handleNotFound(
+      new Request('https://example.workers.dev/api/does-not-exist'),
+      undefined,
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+  });
+
+  it('delegates non-API paths to ASSETS.fetch when the binding IS present', async () => {
+    const fetcher = { fetch: vi.fn().mockResolvedValue(new Response('hi', { status: 200 })) };
+    const req = new Request('https://example.workers.dev/');
+
+    const res = await handleNotFound(req, fetcher as unknown as Fetcher);
+
+    expect(fetcher.fetch).toHaveBeenCalledTimes(1);
+    expect(fetcher.fetch).toHaveBeenCalledWith(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('never delegates /api/* to ASSETS even when present', async () => {
+    const fetcher = { fetch: vi.fn() };
+    const res = await handleNotFound(
+      new Request('https://example.workers.dev/api/missing'),
+      fetcher as unknown as Fetcher,
+    );
+    expect(fetcher.fetch).not.toHaveBeenCalled();
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -29,7 +29,9 @@ export type Env = {
   Bindings: {
     DB: D1Database;
     IMAGES: R2Bucket;
-    ASSETS: Fetcher;
+    // ASSETS is optional: create-ig-harness deploys without an [assets] binding,
+    // so callers MUST guard `env.ASSETS` before invoking `.fetch` (see notFound below).
+    ASSETS?: Fetcher;
     IG_APP_SECRET: string;
     IG_ACCESS_TOKEN: string;
     IG_USER_ID: string;
@@ -234,14 +236,24 @@ app.get('/terms-of-service', (c) => {
 });
 
 // 404 fallback — API paths return JSON 404, everything else serves from static assets (admin)
-app.notFound(async (c) => {
-  const path = new URL(c.req.url).pathname;
+export async function handleNotFound(
+  request: Request,
+  assets: Fetcher | undefined,
+): Promise<Response> {
+  const path = new URL(request.url).pathname;
   if (path.startsWith('/api/') || path === '/webhook' || path === '/docs' || path === '/openapi.json') {
-    return c.json({ success: false, error: 'Not found' }, 404);
+    return Response.json({ success: false, error: 'Not found' }, { status: 404 });
   }
-  // Serve static assets (admin dashboard)
-  return c.env.ASSETS.fetch(c.req.raw);
-});
+  // Serve static assets (admin dashboard) when the [assets] binding is configured.
+  // create-ig-harness quickstart deploys without it — fall back to JSON 404 so we
+  // never invoke `.fetch` on an undefined binding (was logging TypeError on every /).
+  if (assets) {
+    return assets.fetch(request);
+  }
+  return Response.json({ success: false, error: 'Not found' }, { status: 404 });
+}
+
+app.notFound((c) => handleNotFound(c.req.raw, c.env.ASSETS));
 
 // Scheduled handler for cron triggers
 async function scheduled(


### PR DESCRIPTION
## Summary
- Fixes #3
- Make the Worker ASSETS binding optional because create-ig-harness deploy templates can omit [assets]
- Route not-found handling through a guard that falls back to JSON 404 instead of calling undefined.fetch
- Add regression coverage for missing ASSETS, API 404s, and ASSETS delegation

## Verification
- pnpm --filter @ig-harness/ig-sdk build
- pnpm --filter @ig-harness/shared build
- pnpm --filter worker test -- src/__tests__/not-found.test.ts
- pnpm --filter worker build
- git diff --check

## Notes
- pnpm --filter worker typecheck still fails on pre-existing unrelated route type drift in forms/friends/scenarios/webhook/step-delivery; not broadened in this PR.