### PR TITLE
fix(create-ig-harness): harden update and wrangler flow

### DIFF
--- a/docs/UNIFIED-MA-DASHBOARD.md
+++ b/docs/UNIFIED-MA-DASHBOARD.md
@@ -1,0 +1,83 @@
+# Unified MA Dashboard Direction
+
+IG Harness should stay useful as a standalone OSS product, but the product
+direction is a unified marketing automation dashboard that can operate IG,
+LINE, and X from one place.
+
+## Target shape
+
+```text
+Unified Dashboard / Operator
+  -> Connector registry
+      -> LINE Harness Worker API
+      -> IG Harness Worker API
+      -> X Harness Worker API
+  -> Shared identity graph
+      -> platform_user_links
+      -> tracked links / forms / verification callbacks
+  -> Campaign orchestration
+      -> audience, trigger, eligibility, delivery, analytics
+```
+
+Each Harness owns platform-specific auth, webhook handling, API limits, and
+delivery primitives. The unified dashboard owns campaign composition and gives
+operators one UX for cross-platform journeys.
+
+## Connector contract
+
+Every Harness should expose a small common surface:
+
+- `GET /api/health`
+- `GET /api/staff/me`
+- `GET /api/capabilities`
+- `GET /api/connectors`
+- `POST /api/connectors/test`
+- `POST /api/tracked-links`
+- `GET /api/tracked-links/:id/clicks`
+- `POST /api/identity/link`
+- `POST /api/identity/resolve`
+
+Platform-specific APIs can remain as-is. The common connector APIs let a future
+dashboard discover what a deployment can do without hardcoding product-specific
+assumptions.
+
+## Identity model
+
+Use a stable internal `person_id` and attach platform identities to it:
+
+```text
+person_id
+  line_friend_id
+  ig_igsid / ig_scoped_user_id
+  x_user_id / x_username
+  email / phone / external_id
+```
+
+Tracked links and LIFF/forms should carry signed attribution params. A click or
+form submission should upsert an identity link, then notify the originating
+Harness through a webhook.
+
+## CLI direction
+
+The `create-*` CLIs should converge on the same operational behavior:
+
+- `--help` and `--version` must never clone, authenticate, or deploy.
+- `setup` may clone the product repo, create resources, and write resumable
+  setup state.
+- `update` should not clone by default. It should read deployed state and call
+  Cloudflare APIs directly.
+- Deployed state should be small, explicit, and portable:
+  worker name/url, admin project/url, D1 name/id, R2 bucket, account id.
+- Secrets should not remain in resumable setup state after success.
+- Wrangler calls should pin the selected Cloudflare account and retry auth
+  refresh in TTY mode when needed.
+
+## Near-term IG work
+
+1. Harden `create-ig-harness update` so it does not unexpectedly clone/pull.
+2. Add a first-class LINE connection setup step to IG, matching the existing
+   `line_harness_connections` worker API.
+3. Add `/api/capabilities` to IG and LINE so a dashboard can discover features.
+4. Move X's ad-hoc LINE form creation into a reusable connector contract.
+5. Start a separate `ma-dashboard` app only after the connector contract is
+   stable enough to avoid a brittle three-product mega-refactor.

--- a/packages/create-ig-harness/src/commands/setup.ts
+++ b/packages/create-ig-harness/src/commands/setup.ts
@@ -14,6 +14,7 @@ import { setSecrets } from "../steps/secrets.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
 import { showWebhookGuide } from "../steps/webhook-guide.js";
 import { generateApiKey } from "../lib/crypto.js";
+import { setAccountId } from "../lib/wrangler.js";
 
 interface SetupState {
   metaAppId?: string;
@@ -92,6 +93,7 @@ export async function runSetup(repoDir: string): Promise<void> {
     saveState(repoDir, state);
     p.log.success(`Cloudflare アカウント: ${accountId}`);
   }
+  setAccountId(state.accountId);
 
   // Step 3: Get Meta / Instagram credentials (skip if already saved)
   if (!isDone(state, "credentials")) {

--- a/packages/create-ig-harness/src/commands/update.ts
+++ b/packages/create-ig-harness/src/commands/update.ts
@@ -2,7 +2,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { existsSync, readFileSync } from "node:fs";
 import { ensureAuth } from "../steps/auth.js";
-import { wrangler } from "../lib/wrangler.js";
+import { setAccountId, wrangler } from "../lib/wrangler.js";
 import { deployWorker } from "../steps/deploy-worker.js";
 import { join } from "node:path";
 import { execa } from "execa";
@@ -37,6 +37,16 @@ export async function runUpdate(repoDir: string): Promise<void> {
   await ensureAuth();
 
   const deployedState = loadDeployedState(repoDir);
+  if (!deployedState) {
+    p.log.warn(
+      [
+        ".ig-harness-deployed.json が見つかりません。",
+        "初回セットアップ済みの repo で `create-ig-harness update --repo-dir <path>` を実行するか、",
+        "~/.ig-harness/.ig-harness-deployed.json に deployed state を配置してください。",
+      ].join("\n"),
+    );
+  }
+  if (deployedState?.accountId) setAccountId(deployedState.accountId);
   const s = p.spinner();
 
   // Run pending migrations against the user's actual D1 (use saved name)

--- a/packages/create-ig-harness/src/index.ts
+++ b/packages/create-ig-harness/src/index.ts
@@ -1,8 +1,10 @@
-import { readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runSetup } from "./commands/setup.js";
 import { runUpdate } from "./commands/update.js";
+import { WranglerError } from "./lib/wrangler.js";
 import { ensureRepo } from "./steps/clone-repo.js";
 
 const args = process.argv.slice(2);
@@ -64,6 +66,16 @@ function parseArgs(): {
   return { command, repoDir, help, version };
 }
 
+function getConfigDir(explicitRepoDir: string | null): string {
+  if (explicitRepoDir) return explicitRepoDir;
+  const cwdState = join(process.cwd(), ".ig-harness-deployed.json");
+  if (existsSync(cwdState)) return process.cwd();
+  const home = homedir() || process.env.HOME || process.env.USERPROFILE || tmpdir();
+  const dir = join(home, ".ig-harness");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
 async function main(): Promise<void> {
   const { command, repoDir: explicitRepoDir, help, version } = parseArgs();
 
@@ -77,12 +89,14 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Ensure repo is available (clone if needed)
-  const repoDir = await ensureRepo(explicitRepoDir);
-
   if (command === "setup") {
+    // Setup needs the actual template repo so it can deploy Worker/Admin code.
+    const repoDir = await ensureRepo(explicitRepoDir);
     await runSetup(repoDir);
   } else if (command === "update") {
+    // Update reads persisted deployed state and talks to Cloudflare directly.
+    // Avoid a surprising clone/pull when operators only want to redeploy.
+    const repoDir = getConfigDir(explicitRepoDir);
     await runUpdate(repoDir);
   } else {
     console.error(`Unknown command: ${command}`);
@@ -93,5 +107,9 @@ async function main(): Promise<void> {
 
 main().catch((error) => {
   console.error("Error:", error.message);
+  if (error instanceof WranglerError) {
+    const help = error.getHelp();
+    if (help) console.error(`\nHint:\n${help}`);
+  }
   process.exit(1);
 });

--- a/packages/create-ig-harness/src/lib/wrangler.ts
+++ b/packages/create-ig-harness/src/lib/wrangler.ts
@@ -8,17 +8,83 @@ export class WranglerError extends Error {
     super(message);
     this.name = "WranglerError";
   }
+
+  getHelp(): string | null {
+    const text = `${this.message}\n${this.stderr}`.toLowerCase();
+    const hints: string[] = [];
+
+    if (text.includes("code: 10034") || text.includes("code:10034")) {
+      hints.push(
+        "Cloudflare アカウントのメール認証が完了していません。Cloudflare ダッシュボードに届く確認メールを開いて認証してください。",
+      );
+    }
+    if (
+      text.includes("authentication error") ||
+      text.includes("code: 10000") ||
+      text.includes("code:10000")
+    ) {
+      hints.push(
+        "認証 / アカウント不一致の可能性があります。`npx wrangler whoami` でログイン中の Cloudflare アカウントを確認してください。",
+      );
+    }
+    if (text.includes("not authenticated") || text.includes("you are not authenticated")) {
+      hints.push("OAuth トークンが切れています。`npx wrangler logout && npx wrangler login` で再ログインしてください。");
+    }
+    if (text.includes("non-interactive") || text.includes("cloudflare_api_token")) {
+      hints.push(
+        "wrangler が TTY 不在で認証更新できない状態です。CLI が対話モードで再試行できない箇所なら Issue で報告してください。",
+      );
+    }
+    if (text.includes("d1_create_too_many_databases") || text.includes("too many databases")) {
+      hints.push("D1 の無料枠を使い切っています。古い D1 を削除するか有料プランへ移行してください。");
+    }
+
+    return hints.length > 0 ? hints.join("\n") : null;
+  }
+}
+
+let accountId: string | undefined;
+
+export function setAccountId(id: string): void {
+  accountId = id;
+}
+
+export interface WranglerOptions {
+  input?: string;
+  cwd?: string;
+  tty?: boolean;
 }
 
 export async function wrangler(
   args: string[],
-  options?: { input?: string; cwd?: string },
+  options?: WranglerOptions,
 ): Promise<string> {
+  const env: Record<string, string> = { ...process.env, FORCE_COLOR: "0" } as Record<string, string>;
+  if (accountId) env.CLOUDFLARE_ACCOUNT_ID = accountId;
+
+  if (options?.tty) {
+    if (options.input !== undefined) {
+      throw new Error("wrangler({ tty: true }) does not support input.");
+    }
+    try {
+      await execa("npx", ["wrangler", ...args], {
+        cwd: options.cwd,
+        env,
+        stdio: "inherit",
+      });
+      return "";
+    } catch (error: any) {
+      const message = error?.shortMessage || error?.message || "unknown error";
+      throw new WranglerError(`wrangler ${args[0]} failed: ${message}`, "");
+    }
+  }
+
+  const input = options?.input ?? "y\n".repeat(50);
   try {
     const result = await execa("npx", ["wrangler", ...args], {
       cwd: options?.cwd,
-      input: options?.input,
-      env: { ...process.env, FORCE_COLOR: "0" },
+      input,
+      env,
     });
     return result.stdout;
   } catch (error: any) {
@@ -36,7 +102,7 @@ export async function wrangler(
 export async function wranglerInteractive(args: string[]): Promise<void> {
   await execa("npx", ["wrangler", ...args], {
     stdio: "inherit",
-    env: { ...process.env, FORCE_COLOR: "1" },
+    env: { ...process.env, FORCE_COLOR: "1", ...(accountId ? { CLOUDFLARE_ACCOUNT_ID: accountId } : {}) },
   });
 }
 

--- a/packages/create-ig-harness/src/steps/deploy-worker.ts
+++ b/packages/create-ig-harness/src/steps/deploy-worker.ts
@@ -1,7 +1,10 @@
 import * as p from "@clack/prompts";
 import { writeFileSync, existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { wrangler } from "../lib/wrangler.js";
+import { wrangler, WranglerError } from "../lib/wrangler.js";
+
+const WORKERS_DEV_URL = /(https:\/\/[^\s]+\.workers\.dev)/;
+const TTY_REQUIRED = /non[- ]?interactive|cloudflare_api_token|consent denied|authentication error|expired/i;
 
 interface DeployWorkerOptions {
   repoDir: string;
@@ -48,15 +51,42 @@ crons = ["*/5 * * * *"]
   writeFileSync(deployTomlPath, deployToml);
 
   try {
-    const output = await wrangler(["deploy", "--config", deployTomlName], {
-      cwd: workerDir,
-    });
+    let workerUrl: string;
+    try {
+      const output = await wrangler(["deploy", "--config", deployTomlName], {
+        cwd: workerDir,
+      });
+      const urlMatch = output.match(WORKERS_DEV_URL);
+      if (!urlMatch) {
+        throw new Error(`Worker URL を出力からパースできません:\n${output}`);
+      }
+      workerUrl = urlMatch[1];
+    } catch (firstError) {
+      const isAuthError =
+        firstError instanceof WranglerError &&
+        TTY_REQUIRED.test(firstError.stderr);
+      if (!isAuthError) throw firstError;
 
-    // Parse worker URL from output
-    const urlMatch = output.match(/(https:\/\/[^\s]+\.workers\.dev)/);
-    const workerUrl = urlMatch
-      ? urlMatch[1]
-      : `https://${options.workerName}.workers.dev`;
+      s.stop("wrangler 認証更新のため対話モードで再実行します...");
+      await wrangler(["deploy", "--config", deployTomlName], {
+        cwd: workerDir,
+        tty: true,
+      });
+
+      const output = await wrangler(["deploy", "--config", deployTomlName], {
+        cwd: workerDir,
+      });
+      const urlMatch = output.match(WORKERS_DEV_URL);
+      if (!urlMatch) {
+        throw new Error(
+          [
+            "Worker のデプロイは完了しましたが URL を取得できませんでした。",
+            "もう一度同じ update/setup コマンドを実行すると URL 取得を再試行します。",
+          ].join("\n"),
+        );
+      }
+      workerUrl = urlMatch[1];
+    }
 
     s.stop("Worker デプロイ完了");
     return { workerUrl };


### PR DESCRIPTION
## Summary
- Make `create-ig-harness update` avoid an implicit repo clone/pull; it now reads deployed state from `--repo-dir`, cwd, or `~/.ig-harness`
- Pin wrangler commands to the selected Cloudflare account during setup/update
- Add wrangler TTY retry support for OAuth refresh / non-interactive deploy failures
- Require parsing the real workers.dev URL from wrangler deploy output instead of guessing hostnames
- Add a unified MA dashboard direction doc for IG/LINE/X connector boundaries

## Verification
- pnpm --filter create-ig-harness build
- node packages/create-ig-harness/dist/index.js --help
- node packages/create-ig-harness/dist/index.js --version
- git diff --check

## Notes
This is the first foundation pass toward a unified X / LINE / IG MA dashboard. Follow-up work should add first-class capabilities/connector APIs and align X Harness LINE integration with IG line_harness_connections.