### PR TITLE
feat(worker): expose IG connector capabilities

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -23,6 +23,7 @@ import { posts } from './routes/posts.js';
 import { richMessages } from './routes/rich-messages.js';
 import { integrations } from './routes/integrations.js';
 import { lineConnections } from './routes/line-connections.js';
+import { capabilities } from './routes/capabilities.js';
 import { getIGAccessToken, refreshIGAccessTokenIfNeeded } from './lib/ig-token.js';
 
 export type Env = {
@@ -78,6 +79,7 @@ app.route('/', posts);
 app.route('/', richMessages);
 app.route('/', integrations);
 app.route('/', lineConnections);
+app.route('/', capabilities);
 
 // LINE Harness UUID linkage endpoint
 app.get('/connect', (c) => {

--- a/apps/worker/src/routes/capabilities.ts
+++ b/apps/worker/src/routes/capabilities.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono';
+import type { Env } from '../index.js';
+
+export const IG_CAPABILITIES = {
+  product: 'ig-harness',
+  platform: 'instagram',
+  version: '0.5.3',
+  connectorVersion: '2026-05-20',
+  identity: {
+    primaryUserKey: 'ig_igsid',
+    supportedLinks: ['line_friend_id'],
+  },
+  features: [
+    'comments-to-dm',
+    'comment-auto-reply',
+    'engagement-gates',
+    'follow-check',
+    'line-cross-link',
+    'tracked-links',
+    'forms',
+    'broadcasts',
+    'rich-messages',
+    'step-delivery',
+    'mcp',
+  ],
+  endpoints: {
+    health: '/api/health',
+    staffMe: '/api/staff/me',
+    lineConnections: '/api/line-connections',
+    trackedLinks: '/api/tracked-links',
+    identityLink: '/api/followers/link-line',
+  },
+} as const;
+
+export const capabilities = new Hono<Env>();
+
+capabilities.get('/api/capabilities', (c) => {
+  return c.json({ success: true, data: IG_CAPABILITIES });
+});

--- a/docs/UNIFIED-MA-DASHBOARD.md
+++ b/docs/UNIFIED-MA-DASHBOARD.md
@@ -75,9 +75,10 @@ The `create-*` CLIs should converge on the same operational behavior:
 ## Near-term IG work
 
 1. Harden `create-ig-harness update` so it does not unexpectedly clone/pull.
-2. Add a first-class LINE connection setup step to IG, matching the existing
+2. Add `GET /api/capabilities` to IG as the first connector-discovery endpoint.
+3. Add a first-class LINE connection setup step to IG, matching the existing
    `line_harness_connections` worker API.
-3. Add `/api/capabilities` to IG and LINE so a dashboard can discover features.
-4. Move X's ad-hoc LINE form creation into a reusable connector contract.
-5. Start a separate `ma-dashboard` app only after the connector contract is
+4. Add `/api/capabilities` to LINE and X so a dashboard can discover features.
+5. Move X's ad-hoc LINE form creation into a reusable connector contract.
+6. Start a separate `ma-dashboard` app only after the connector contract is
    stable enough to avoid a brittle three-product mega-refactor.


### PR DESCRIPTION
## Summary
- Add authenticated `GET /api/capabilities` for unified MA dashboard discovery
- Publish IG Harness platform/features/endpoints metadata from the Worker
- Update the unified MA dashboard direction doc to mark IG capabilities as the first connector-discovery endpoint

## Verification
- pnpm --filter worker typecheck
- pnpm --filter worker build
- pnpm --filter worker test
- git diff --check